### PR TITLE
Add support for div, mod and divMod

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -47,6 +47,13 @@ measureInt name f = bench name $
     $ measureInt "quoteQuot" $$(quoteQuot (n :: Int)) \
     ]
 
+#define benchDivInt(n) \
+  bgroup (show (n :: Int)) \
+    [ measureInt "div" (`div` (n :: Int)) \
+    , bcompare ("$NF == \"div\" && $(NF-1) == \"" ++ show (n :: Int) ++ "\" && $(NF-2) == \"Int\"") \
+    $ measureInt "quoteDiv" $$(quoteDiv (n :: Int)) \
+    ]
+
 main :: IO ()
 main = defaultMain
   [ bgroup "Word"
@@ -60,7 +67,13 @@ main = defaultMain
     [ benchInt(3)
     , benchInt(5)
     , benchInt(7)
-    , benchWord(10000)
+    , benchInt(10000)
+    ]
+  , bgroup "DivInt"
+    [ benchDivInt(3)
+    , benchDivInt(5)
+    , benchDivInt(7)
+    , benchDivInt(10000)
     ]
 #endif
   ]

--- a/quote-quot.cabal
+++ b/quote-quot.cabal
@@ -30,7 +30,8 @@ library
   default-language: Haskell2010
   ghc-options:      -Wall -Wcompat
   build-depends:
-    base >=4.18 && < 5
+    base >=4.18 && < 5,
+    template-haskell >=2.17 && <2.24
 
 test-suite quote-quot-tests
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
With `div` the positive case is identical to `quot` and the negative case is handled by observing that that for $`n < 0`$ and $`d > 0`$, we have:

$$\big\lfloor \frac{n}{d} \big\rfloor = - \big\lfloor \frac{-n-1}d \big\rfloor-1$$

in which the numerator $`({-n}-1)`$ can be assumed non-negative.